### PR TITLE
[Fix] Add missing suppress lint

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Audio/AudioCompressor.java
+++ b/android/src/main/java/com/reactnativecompressor/Audio/AudioCompressor.java
@@ -407,7 +407,7 @@ public class AudioCompressor {
     return -1;
   }
 
-
+  @SuppressLint("WrongConstant")
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
   private long writeAudioTrack(MediaExtractor extractor, MediaMuxer mediaMuxer, MediaCodec.BufferInfo info, File file, int muxerTrackIndex ) throws Exception {
     int trackIndex = selectTrack(extractor, true);


### PR DESCRIPTION
## Problem
Lint Error:
Audio/AudioCompressor.java:452: Error: Must be one or more of: MediaCodec.BUFFER_FLAG_SYNC_FRAME, MediaCodec.BUFFER_FLAG_KEY_FRAME, MediaCodec.BUFFER_FLAG_CODEC_CONFIG, MediaCodec.BUFFER_FLAG_END_OF_STREAM, MediaCodec.BUFFER_FLAG_PARTIAL_FRAME, but could be MediaExtractor.SAMPLE_FLAG_SYNC, MediaExtractor.SAMPLE_FLAG_ENCRYPTED, MediaExtractor.SAMPLE_FLAG_PARTIAL_FRAME [WrongConstant]
        audioBufferInfo.flags = extractor.getSampleFlags();
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "WrongConstant":
   Ensures that when parameter in a method only allows a specific set of
   constants, calls obey those rules.

## Changelog
Added MissingConstant SuppressLint


