### PR TITLE
fix: build error with xcode 13

### DIFF
--- a/ios/Utils/Uploader.swift
+++ b/ios/Utils/Uploader.swift
@@ -132,7 +132,7 @@ class Uploader : NSObject, URLSessionTaskDelegate{
     }
     
     func headersForMultipartParams(_ params: [String: String]?, boundary: String) -> String {
-      guard let params else {
+      guard let params = params else {
         return ""
       }
       return params.map { (key: String, value: String) in


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
```
xcodebuild -version

> Xcode 13.4.1
> Build version 13F100
```
![Screen Shot 2023-10-12 at 20 03 52](https://github.com/numandev1/react-native-compressor/assets/85035176/408b2b38-abff-45a2-87d0-ab10c2589880)



It looks like ```guard let params``` is only supported in more recent swift versions.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
change ```guard let params``` to ```guard let params = params```

