### PR TITLE
#212 Cancel background upload

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,8 +78,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 
   sourceSets {

--- a/android/src/main/java/com/reactnativecompressor/CompressorModule.kt
+++ b/android/src/main/java/com/reactnativecompressor/CompressorModule.kt
@@ -126,6 +126,11 @@ class CompressorModule(private val reactContext: ReactApplicationContext) : Comp
   }
 
   @ReactMethod
+  override fun cancelUpload() {
+    uploader.cancelUpload()
+  }
+
+  @ReactMethod
   override fun download(
     fileUrl: String,
     options: ReadableMap,

--- a/android/src/oldarch/CompressorSpec.kt
+++ b/android/src/oldarch/CompressorSpec.kt
@@ -23,6 +23,7 @@ abstract class CompressorSpec(context: ReactApplicationContext?) : ReactContextB
     abstract fun compress(fileUrl: String, optionMap: ReadableMap, promise: Promise)
     abstract fun cancelCompression(uuid: String)
     abstract fun upload(fileUrl: String, options: ReadableMap, promise: Promise)
+    abstract fun cancelUpload()
 
     abstract fun download(fileUrl: String, options: ReadableMap, promise: Promise)
     abstract fun activateBackgroundTask(options: ReadableMap, promise: Promise)

--- a/example/ios/CompressorExample.xcodeproj/project.pbxproj
+++ b/example/ios/CompressorExample.xcodeproj/project.pbxproj
@@ -594,14 +594,14 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -663,14 +663,14 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/example/ios/Gemfile.lock
+++ b/example/ios/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       rexml (~> 3.2.4)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-22

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,6 +2,13 @@ PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
+  - FBReactNativeSpec (0.72.4):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTRequired (= 0.72.4)
+    - RCTTypeSafety (= 0.72.4)
+    - React-Core (= 0.72.4)
+    - React-jsi (= 0.72.4)
+    - ReactCommon/turbomodule/core (= 0.72.4)
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.72.4):
@@ -16,11 +23,6 @@ PODS:
     - glog
     - RCT-Folly/Default (= 2021.07.22.00)
   - RCT-Folly/Default (2021.07.22.00):
-    - boost
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-  - RCT-Folly/Fabric (2021.07.22.00):
     - boost
     - DoubleConversion
     - fmt (~> 6.2.1)
@@ -52,19 +54,17 @@ PODS:
   - React-callinvoker (0.72.4)
   - React-Codegen (0.72.4):
     - DoubleConversion
+    - FBReactNativeSpec
     - glog
     - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
-    - React-utils
+    - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - React-Core (0.72.4):
@@ -288,555 +288,6 @@ PODS:
     - React-perflogger (= 0.72.4)
     - React-runtimeexecutor (= 0.72.4)
   - React-debug (0.72.4)
-  - React-Fabric (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-Fabric/animations (= 0.72.4)
-    - React-Fabric/attributedstring (= 0.72.4)
-    - React-Fabric/butter (= 0.72.4)
-    - React-Fabric/componentregistry (= 0.72.4)
-    - React-Fabric/componentregistrynative (= 0.72.4)
-    - React-Fabric/components (= 0.72.4)
-    - React-Fabric/config (= 0.72.4)
-    - React-Fabric/core (= 0.72.4)
-    - React-Fabric/debug_renderer (= 0.72.4)
-    - React-Fabric/imagemanager (= 0.72.4)
-    - React-Fabric/leakchecker (= 0.72.4)
-    - React-Fabric/mapbuffer (= 0.72.4)
-    - React-Fabric/mounting (= 0.72.4)
-    - React-Fabric/scheduler (= 0.72.4)
-    - React-Fabric/telemetry (= 0.72.4)
-    - React-Fabric/templateprocessor (= 0.72.4)
-    - React-Fabric/textlayoutmanager (= 0.72.4)
-    - React-Fabric/uimanager (= 0.72.4)
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/animations (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/attributedstring (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/butter (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/componentregistry (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/componentregistrynative (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-Fabric/components/activityindicator (= 0.72.4)
-    - React-Fabric/components/image (= 0.72.4)
-    - React-Fabric/components/inputaccessory (= 0.72.4)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.72.4)
-    - React-Fabric/components/modal (= 0.72.4)
-    - React-Fabric/components/rncore (= 0.72.4)
-    - React-Fabric/components/root (= 0.72.4)
-    - React-Fabric/components/safeareaview (= 0.72.4)
-    - React-Fabric/components/scrollview (= 0.72.4)
-    - React-Fabric/components/text (= 0.72.4)
-    - React-Fabric/components/textinput (= 0.72.4)
-    - React-Fabric/components/unimplementedview (= 0.72.4)
-    - React-Fabric/components/view (= 0.72.4)
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/activityindicator (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/image (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/inputaccessory (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/legacyviewmanagerinterop (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/modal (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/rncore (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/root (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/safeareaview (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/scrollview (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/text (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/textinput (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/unimplementedview (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/components/view (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-    - Yoga
-  - React-Fabric/config (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/core (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/debug_renderer (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/imagemanager (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/leakchecker (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/mapbuffer (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/mounting (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/scheduler (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/telemetry (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/templateprocessor (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/textlayoutmanager (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-Fabric/uimanager
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-Fabric/uimanager (0.72.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsiexecutor (= 0.72.4)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-graphics (0.72.4):
-    - glog
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.4)
   - React-hermes (0.72.4):
     - DoubleConversion
     - glog
@@ -848,14 +299,6 @@ PODS:
     - React-jsiexecutor (= 0.72.4)
     - React-jsinspector (= 0.72.4)
     - React-perflogger (= 0.72.4)
-  - React-ImageManager (0.72.4):
-    - glog
-    - RCT-Folly/Fabric
-    - React-Core/Default
-    - React-debug
-    - React-Fabric
-    - React-RCTImage
-    - React-utils
   - React-jsi (0.72.4):
     - boost (= 1.76.0)
     - DoubleConversion
@@ -874,98 +317,19 @@ PODS:
   - React-logger (0.72.4):
     - glog
   - react-native-cameraroll (5.7.2):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
+    - React-Core
   - react-native-compressor (1.8.13):
-    - hermes-engine
     - NextLevelSessionExporter
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - react-native-document-picker (9.0.1):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - ReactCommon/turbomodule/core
   - react-native-get-random-values (1.9.0):
     - React-Core
   - react-native-image-picker (5.6.1):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
+    - React-Core
   - react-native-safe-area-context (4.7.1):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - react-native-safe-area-context/common (= 4.7.1)
-    - react-native-safe-area-context/fabric (= 4.7.1)
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - react-native-safe-area-context/common (4.7.1):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - react-native-safe-area-context/fabric (4.7.1):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - react-native-safe-area-context/common
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
     - React-callinvoker
@@ -991,15 +355,11 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
-    - React-debug
-    - React-graphics
     - React-hermes
     - React-NativeModulesApple
-    - React-RCTFabric
     - React-RCTImage
     - React-RCTNetwork
     - React-runtimescheduler
-    - React-utils
     - ReactCommon/turbomodule/core
   - React-RCTBlob (0.72.4):
     - hermes-engine
@@ -1010,18 +370,6 @@ PODS:
     - React-jsi (= 0.72.4)
     - React-RCTNetwork (= 0.72.4)
     - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTFabric (0.72.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core (= 0.72.4)
-    - React-Fabric (= 0.72.4)
-    - React-ImageManager
-    - React-RCTImage (= 0.72.4)
-    - React-RCTText
-    - React-runtimescheduler
-    - React-utils
-    - Yoga
   - React-RCTImage (0.72.4):
     - RCT-Folly (= 2021.07.22.00)
     - RCTTypeSafety (= 0.72.4)
@@ -1105,7 +453,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-callinvoker
-    - React-Codegen
     - React-Core
     - React-Core/DevSupport
     - React-Core/RCTWebSocket
@@ -1117,8 +464,8 @@ PODS:
     - React-jsinspector
     - React-RCTActionSheet
     - React-RCTAnimation
+    - React-RCTAppDelegate
     - React-RCTBlob
-    - React-RCTFabric
     - React-RCTImage
     - React-RCTLinking
     - React-RCTNetwork
@@ -1127,55 +474,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - RNScreens (3.25.0):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.25.0)
-  - RNScreens/common (3.25.0):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
+    - React-Core
+    - React-RCTImage
   - RNSVG (13.13.0):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNSVG/common (= 13.13.0)
-    - Yoga
-  - RNSVG/common (13.13.0):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
 
@@ -1183,11 +485,11 @@ DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
+  - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
-  - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native/`)
@@ -1198,10 +500,7 @@ DEPENDENCIES:
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
   - React-debug (from `../node_modules/react-native/ReactCommon/react/debug`)
-  - React-Fabric (from `../node_modules/react-native/ReactCommon`)
-  - React-graphics (from `../node_modules/react-native/ReactCommon/react/renderer/graphics`)
   - React-hermes (from `../node_modules/react-native/ReactCommon/hermes`)
-  - React-ImageManager (from `../node_modules/react-native/ReactCommon/react/renderer/imagemanager/platform/ios`)
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
@@ -1218,7 +517,6 @@ DEPENDENCIES:
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTAppDelegate (from `../node_modules/react-native/Libraries/AppDelegate`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
-  - React-RCTFabric (from `../node_modules/react-native/React`)
   - React-RCTImage (from `../node_modules/react-native/Libraries/Image`)
   - React-RCTLinking (from `../node_modules/react-native/Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../node_modules/react-native/Libraries/Network`)
@@ -1251,6 +549,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
+  FBReactNativeSpec:
+    :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
@@ -1276,14 +576,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/cxxreact"
   React-debug:
     :path: "../node_modules/react-native/ReactCommon/react/debug"
-  React-Fabric:
-    :path: "../node_modules/react-native/ReactCommon"
-  React-graphics:
-    :path: "../node_modules/react-native/ReactCommon/react/renderer/graphics"
   React-hermes:
     :path: "../node_modules/react-native/ReactCommon/hermes"
-  React-ImageManager:
-    :path: "../node_modules/react-native/ReactCommon/react/renderer/imagemanager/platform/ios"
   React-jsi:
     :path: "../node_modules/react-native/ReactCommon/jsi"
   React-jsiexecutor:
@@ -1316,8 +610,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/AppDelegate"
   React-RCTBlob:
     :path: "../node_modules/react-native/Libraries/Blob"
-  React-RCTFabric:
-    :path: "../node_modules/react-native/React"
   React-RCTImage:
     :path: "../node_modules/react-native/Libraries/Image"
   React-RCTLinking:
@@ -1357,6 +649,7 @@ SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
+  FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 81191603c4eaa01f5e4ae5737a9efcf64756c7b2
@@ -1367,48 +660,44 @@ SPEC CHECKSUMS:
   RCTTypeSafety: e90354072c21236e0bcf1699011e39acd25fea2f
   React: a1be3c6dc0a6e949ccd3e659781aa47bbae1868f
   React-callinvoker: 1020b33f6cb1a1824f9ca2a86609fbce2a73c6ed
-  React-Codegen: 0a4f532a16541eebba4b7f5dd2e69a396911f1bf
+  React-Codegen: a0a26badf098d4a779acda922caf74f6ecabed28
   React-Core: 52075b80f10c26f62219d7b5d13d7d8089f027b3
   React-CoreModules: 21abab85d7ad9038ce2b1c33d39e3baaf7dc9244
   React-cxxreact: 4ad1cc861e32fb533dad6ff7a4ea25680fa1c994
   React-debug: 17366a3d5c5d2f5fc04f09101a4af38cb42b54ae
-  React-Fabric: bd595702c2a473faca32b59c427d927e9d3a4cc1
-  React-graphics: 89d631f399096ffb5f93e19ca6908ba93a123797
   React-hermes: 37377d0a56aa0cf55c65248271866ce3268cde3f
-  React-ImageManager: e57287a6a9d34b95c5f348a2f8773d9f6007c507
   React-jsi: 6de8b0ccc6b765b58e4eee9ee38049dbeaf5c221
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-cameraroll: 5d9523136a929b58f092fd7f0a9a13367a4b46e3
-  react-native-compressor: 36560ed68379f0fe9b52b2ee8c1e3d9853dd86b8
-  react-native-document-picker: c9ac93d7b511413f4a0ed61c92ff6c7b1bcf4f94
+  react-native-cameraroll: 134805127580aed23403b8c2cb1548920dd77b3a
+  react-native-compressor: 63837ba06de7f5f2716eb5a2ce41ddffbaae6069
+  react-native-document-picker: 2b8f18667caee73a96708a82b284a4f40b30a156
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
-  react-native-image-picker: 9b4b1d0096500050cbdabf8f4fd00b771065d983
-  react-native-safe-area-context: a283130af276caa22ecfed30c3d1eb450bc83439
+  react-native-image-picker: 5fcac5a5ffcb3737837f0617d43fd767249290de
+  react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
   React-RCTAnimation: 88feaf0a85648fb8fd497ce749829774910276d6
-  React-RCTAppDelegate: 905ab3a3120e31e9f2875a1b5f03f4b812312388
+  React-RCTAppDelegate: 5792ac0f0feccb584765fdd7aa81ea320c4d9b0b
   React-RCTBlob: 0dbc9e2a13d241b37d46b53e54630cbad1f0e141
-  React-RCTFabric: 0d443ab3cc3f0af82442ec95747d503cee955f26
   React-RCTImage: b111645ab901f8e59fc68fbe31f5731bdbeef087
   React-RCTLinking: 3d719727b4c098aad3588aa3559361ee0579f5de
   React-RCTNetwork: b44d3580be05d74556ba4efbf53570f17e38f734
   React-RCTSettings: c0c54b330442c29874cd4dae6e94190dc11a6f6f
   React-RCTText: 9b9f5589d9b649d7246c3f336e116496df28cfe6
   React-RCTVibration: 691c67f3beaf1d084ceed5eb5c1dddd9afa8591e
-  React-rncore: 705a03a7c9db5287f82da01a4ed5f7ed5c7dab0f
+  React-rncore: 142268f6c92e296dc079aadda3fade778562f9e4
   React-runtimeexecutor: d465ba0c47ef3ed8281143f59605cacc2244d5c7
   React-runtimescheduler: 4941cc1b3cf08b792fbf666342c9fc95f1969035
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNReanimated: 5008fe999d57038a1c5c1163044854d453f41b98
-  RNScreens: cba72a26a6c967765a8388fe85f78e7771012ca1
-  RNSVG: e136c0e3c70ff4fb98687fc5a887039c436c65e6
+  RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1
+  RNScreens: 85d3880b52d34db7b8eeebe2f1a0e807c05e69fa
+  RNSVG: ed492aaf3af9ca01bc945f7a149d76d62e73ec82
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -881,7 +881,7 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-  - react-native-compressor (1.8.11):
+  - react-native-compressor (1.8.13):
     - hermes-engine
     - NextLevelSessionExporter
     - RCT-Folly (= 2021.07.22.00)
@@ -1381,7 +1381,7 @@ SPEC CHECKSUMS:
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
   react-native-cameraroll: 5d9523136a929b58f092fd7f0a9a13367a4b46e3
-  react-native-compressor: f807dbe3d5dac8cc2efab2adf8bed7949f70d5a9
+  react-native-compressor: 36560ed68379f0fe9b52b2ee8c1e3d9853dd86b8
   react-native-document-picker: c9ac93d7b511413f4a0ed61c92ff6c7b1bcf4f94
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   react-native-image-picker: 9b4b1d0096500050cbdabf8f4fd00b771065d983
@@ -1390,7 +1390,7 @@ SPEC CHECKSUMS:
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
   React-RCTAnimation: 88feaf0a85648fb8fd497ce749829774910276d6
-  React-RCTAppDelegate: c7072d67aee21e2c8f6101060add57b3c2652387
+  React-RCTAppDelegate: 905ab3a3120e31e9f2875a1b5f03f4b812312388
   React-RCTBlob: 0dbc9e2a13d241b37d46b53e54630cbad1f0e141
   React-RCTFabric: 0d443ab3cc3f0af82442ec95747d503cee955f26
   React-RCTImage: b111645ab901f8e59fc68fbe31f5731bdbeef087

--- a/example/src/Screens/Main/index.tsx
+++ b/example/src/Screens/Main/index.tsx
@@ -1,4 +1,4 @@
-import { StackNavigationProp } from '@react-navigation/stack';
+import { type StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import {
   FlatList,
@@ -7,9 +7,11 @@ import {
   Pressable,
   ScrollView,
   View,
+  type StyleProp,
+  type ViewStyle,
 } from 'react-native';
 
-import { SCREENS, Screens } from '..';
+import { SCREENS, type Screens } from '..';
 
 type RootStackParams = { Home: undefined } & { [key: string]: undefined };
 type MainScreenProps = {

--- a/example/src/Screens/Video/index.tsx
+++ b/example/src/Screens/Video/index.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, Button, Image, Alert, Platform } from 'react-native';
+import {
+  View,
+  Text,
+  Button,
+  Image,
+  Alert,
+  Platform,
+  BackHandler,
+} from 'react-native';
 import {
   Video,
   getRealPath,
@@ -23,6 +31,7 @@ const uploadPostRequest = `${DOMAIN}/upload`;
 // const uploadPostRequestFail = `${DOMAIN}/uploadFail`;
 export default function App() {
   const progressRef = useRef<ProgressBarRafType>();
+  const abortSignalRef = useRef(new AbortController());
   const cancellationIdRef = useRef<string>('');
   const [sourceVideo, setSourceVideo] = useState<string>();
   const [sourceSize, setSourceSize] = useState<number>();
@@ -67,7 +76,7 @@ export default function App() {
     if (doingSomething) {
       let counter = 1;
       const timer = setInterval(() => {
-        console.log(counter, ' Doing Simething', new Date());
+        console.log(counter, ' Doing Something', new Date());
         counter += 1;
       }, 500);
       return () => {
@@ -76,6 +85,16 @@ export default function App() {
     }
     return undefined;
   }, [doingSomething]);
+
+  useEffect(() => {
+    const handler = () => {
+      abortSignalRef.current?.abort();
+      return true;
+    };
+    BackHandler.addEventListener('hardwareBackPress', handler);
+
+    return () => BackHandler.removeEventListener('hardwareBackPress', handler);
+  }, []);
 
   const selectVideo = async () => {
     try {
@@ -203,7 +222,8 @@ export default function App() {
         (written, total) => {
           progressRef.current?.setProgress(written / total);
           console.log(written, total);
-        }
+        },
+        abortSignalRef.current.signal
       );
 
       console.log(result, 'result');
@@ -233,7 +253,8 @@ export default function App() {
         (written, total) => {
           progressRef.current?.setProgress(written / total);
           console.log(written, total);
-        }
+        },
+        abortSignalRef.current.signal
       );
 
       console.log(result, 'result');

--- a/example/src/Screens/index.tsx
+++ b/example/src/Screens/index.tsx
@@ -38,12 +38,12 @@ function ThemeStack() {
         options={{ title: 'Compressor Examples' }}
         component={MainScreen}
       />
-      {Object.keys(SCREENS).map((name) => (
+      {Object.entries(SCREENS).map(([name, screen]) => (
         <ThemeNavStack.Screen
           key={name}
           name={name}
-          getComponent={() => SCREENS[name].screen}
-          options={{ title: SCREENS[name].title || name }}
+          getComponent={() => screen.screen}
+          options={{ title: screen.title || name }}
         />
       ))}
     </ThemeNavStack.Navigator>

--- a/exampleExpo/src/Screens/Main/index.tsx
+++ b/exampleExpo/src/Screens/Main/index.tsx
@@ -1,4 +1,4 @@
-import { StackNavigationProp } from '@react-navigation/stack';
+import { type StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import {
   FlatList,
@@ -7,9 +7,11 @@ import {
   Pressable,
   ScrollView,
   View,
+  type StyleProp,
+  type ViewStyle,
 } from 'react-native';
 
-import { SCREENS, Screens } from '..';
+import { SCREENS, type Screens } from '..';
 
 type RootStackParams = { Home: undefined } & { [key: string]: undefined };
 type MainScreenProps = {

--- a/exampleExpo/src/Screens/index.tsx
+++ b/exampleExpo/src/Screens/index.tsx
@@ -38,12 +38,12 @@ function ThemeStack() {
         options={{ title: 'Compressor Examples' }}
         component={MainScreen}
       />
-      {Object.keys(SCREENS).map((name) => (
+      {Object.entries(SCREENS).map(([name, component]) => (
         <ThemeNavStack.Screen
           key={name}
           name={name}
-          getComponent={() => SCREENS[name].screen}
-          options={{ title: SCREENS[name].title || name }}
+          getComponent={() => component.screen}
+          options={{ title: component.title || name }}
         />
       ))}
     </ThemeNavStack.Navigator>

--- a/ios/Compressor.mm
+++ b/ios/Compressor.mm
@@ -39,6 +39,8 @@ RCT_EXTERN_METHOD(upload:(NSString *)fileUrl
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(cancelUpload)
+
 RCT_EXTERN_METHOD(download:(NSString *)fileUrl
                  withOptions:(NSDictionary *)options
                  withResolver:(RCTPromiseResolveBlock)resolve

--- a/ios/CompressorManager.swift
+++ b/ios/CompressorManager.swift
@@ -86,6 +86,10 @@ class Compressor: RCTEventEmitter {
         uploader.upload(filePath: filePath, options: options, resolve: resolve, reject: reject)
     }
     
+    func cancelUpload() -> Void {
+        uploader.cancelUpload()
+    }
+    
     @objc(download:withOptions:withResolver:withRejecter:)
     func download(filePath: String, options: [String: Any], resolve:@escaping RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
         Downloader.downloadFileAndSaveToCache(filePath, uuid: options["uuid"] as! String,progressDivider: options["progressDivider"] as? Int ?? 0) { downloadedPath in

--- a/ios/CompressorManager.swift
+++ b/ios/CompressorManager.swift
@@ -86,6 +86,7 @@ class Compressor: RCTEventEmitter {
         uploader.upload(filePath: filePath, options: options, resolve: resolve, reject: reject)
     }
     
+    @objc(cancelUpload)
     func cancelUpload() -> Void {
         uploader.cancelUpload()
     }

--- a/ios/Utils/Uploader.swift
+++ b/ios/Utils/Uploader.swift
@@ -29,6 +29,7 @@ struct UploadError: Error {
 class Uploader : NSObject, URLSessionTaskDelegate{
     var uploadResolvers: [String: RCTPromiseResolveBlock] = [:]
     var uploadRejectors: [String: RCTPromiseRejectBlock] = [:]
+    var currentTask: URLSessionDataTask?
     
     func upload(filePath: String, options: [String: Any], resolve:@escaping RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
         let fileUrl = Utils.makeValidUri(filePath: filePath)
@@ -98,8 +99,13 @@ class Uploader : NSObject, URLSessionTaskDelegate{
             reject("ERR_FILESYSTEM_INVALID_UPLOAD_TYPE", errorMessage, nil)
         }
         
+        currentTask = task
         task.resume()
      
+    }
+    
+    func cancelUpload() {
+        currentTask?.cancel()
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {

--- a/src/Spec/NativeCompressor.ts
+++ b/src/Spec/NativeCompressor.ts
@@ -14,6 +14,8 @@ export interface Spec extends TurboModule {
   compress_audio(fileUrl: string, optionMap: Object): Promise<string>;
   // Upload
   upload(fileUrl: string, options: Object): Promise<string>;
+  // Cancel upload
+  cancelUpload(): void;
   // Download
   download(fileUrl: string, options: Object): Promise<string>;
   // Others

--- a/src/utils/Uploader.tsx
+++ b/src/utils/Uploader.tsx
@@ -42,7 +42,8 @@ export const backgroundUpload = async (
   url: string,
   fileUrl: string,
   options: UploaderOptions,
-  onProgress?: (writtem: number, total: number) => void
+  onProgress?: (writtem: number, total: number) => void,
+  abortSignal?: AbortSignal
 ): Promise<any> => {
   const uuid = uuidv4();
   let subscription: NativeEventSubscription;
@@ -60,6 +61,11 @@ export const backgroundUpload = async (
     if (Platform.OS === 'android' && fileUrl.includes('file://')) {
       fileUrl = fileUrl.replace('file://', '');
     }
+
+    abortSignal?.addEventListener('abort', () => {
+      Compressor.cancelUpload();
+    });
+
     const result = await Compressor.upload(fileUrl, {
       uuid,
       method: options.httpMethod,

--- a/src/utils/Uploader.tsx
+++ b/src/utils/Uploader.tsx
@@ -38,6 +38,8 @@ export declare type UploaderOptions = (
   httpMethod?: UploaderHttpMethod | HttpMethod;
 };
 
+const cancelUpload = () => Compressor.cancelUpload();
+
 export const backgroundUpload = async (
   url: string,
   fileUrl: string,
@@ -62,9 +64,7 @@ export const backgroundUpload = async (
       fileUrl = fileUrl.replace('file://', '');
     }
 
-    abortSignal?.addEventListener('abort', () => {
-      Compressor.cancelUpload();
-    });
+    abortSignal?.addEventListener('abort', cancelUpload);
 
     const result = await Compressor.upload(fileUrl, {
       uuid,
@@ -80,5 +80,6 @@ export const backgroundUpload = async (
     if (subscription) {
       subscription.remove();
     }
+    abortSignal?.removeEventListener('abort', cancelUpload);
   }
 };


### PR DESCRIPTION
This pull request follows issue https://github.com/numandev1/react-native-compressor/issues/212.
Within `backgroundUpload` there is an AbortController listener that will listen for 'abort' events and call the `cancelUpload` for all pending uploads.

This code is far from done, but hopefully this will jump start the development of this missing feature. 💪🏻

It would be greatly appreciated if @numandev1 takes over from here.

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Being able to cancel an upload is an essential part to prevent leaks in your app.

One issue with this PR in current state is that uploading multiple files at once using an asyncQueue will only cancel the last concurrent upload; the rest will continue uploading. 
Running the asyncQueue with concurrencyLimit of 1 will also lose connection to subsequent uploads. This is not the case with other uploader logic, therefore it is not an issue with the asyncqueue.

## Changelog

FEATURE - Add AbortController's signal to `backgroundUpload`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

There's no server available so I did not test the implementation in the example app. However I did test it in my own app and it is working as I expect it; it throws a `[Error: Socket closed]` on Android and PASTE ERROR on iOS, which is to be expected

Steps to reproduce:
1. Implement an asyncqueue to upload multiple files simultaneously
2. Select multiple files
3. Tap 'upload'
4. Wait for upload to start
5. Tap 'cancel'
6. Confirm upload cancellation
7. See the appropriate logs for cancelling the upload (no progress updates, 'upload cancelled', etc.).