### PR TITLE
fix: upscale and division by zero issue

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Video/AutoVideoCompression.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/AutoVideoCompression.kt
@@ -26,8 +26,8 @@ object AutoVideoCompression {
                 val actualWidth = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
                 val bitrate = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)!!.toInt()
                 val scale = if (actualWidth > actualHeight) maxSize / actualWidth else maxSize / actualHeight
-                val resultWidth = Math.round(actualWidth * scale / 2) * 2
-                val resultHeight = Math.round(actualHeight * scale / 2) * 2
+                val resultWidth = Math.round(actualWidth * Math.min(scale, 1f) / 2) * 2
+                val resultHeight = Math.round(actualHeight * Math.min(scale, 1f) / 2) * 2
                 val videoBitRate = makeVideoBitrate(
                   actualHeight, actualWidth,
                   bitrate,

--- a/ios/Video/VideoMain.swift
+++ b/ios/Video/VideoMain.swift
@@ -154,7 +154,7 @@ class VideoCompressor {
         let minValue:Float=min(Float(originalHeight)/Float(height),Float(originalWidth)/Float(width))
         var remeasuredBitrate:Int = Int(Float(originalBitrate) / minValue)
         remeasuredBitrate = Int(Float(remeasuredBitrate)*compressFactor)
-        let minBitrate:Int = self.getVideoBitrateWithFactor(f: minCompressFactor) / (1280 * 720 / (width * height))
+        let minBitrate:Int = Int(Float(self.getVideoBitrateWithFactor(f: minCompressFactor)) / (1280 * 720 / Float(width * height)))
         if (originalBitrate < minBitrate) {
           return remeasuredBitrate;
         }

--- a/ios/Video/VideoMain.swift
+++ b/ios/Video/VideoMain.swift
@@ -186,8 +186,8 @@ class VideoCompressor {
 
         let bitrate=Float(abs(track.estimatedDataRate));
         let scale:Float = actualWidth > actualHeight ? (Float(maxSize) / actualWidth) : (Float(maxSize) / actualHeight);
-        let resultWidth:Float = round(actualWidth * scale / 2) * 2;
-        let resultHeight:Float = round(actualHeight * scale / 2) * 2;
+        let resultWidth:Float = round(actualWidth * min(scale, 1) / 2) * 2;
+        let resultHeight:Float = round(actualHeight * min(scale, 1) / 2) * 2;
 
         let videoBitRate:Int = self.makeVideoBitrate(
             originalHeight: Int(actualHeight), originalWidth: Int(actualWidth),


### PR DESCRIPTION
## Summary

We use maxSize to downscale larger videos but smaller videos will also be upscaled to the maxSize in auto compression. 
Also there is a division by zero issue when calculating min bitrate. It happens when getVideoBitrateWithFactor is divided by a number < 1. We need to first cast the result to float, make the division and then cast it back to int.

## Changelog

fixed upscale and division by zero issue

## Test Plan

- Try to auto compress a video with maxSize higher than the actual size of the video.
- Try to auto compress a 1080 x 1920 video with maxSize: 8000
