### PR TITLE
fix: call Audio.compress always failed under iOS 17

### DIFF
--- a/ios/Audio/AudioMain.swift
+++ b/ios/Audio/AudioMain.swift
@@ -14,6 +14,7 @@ let AlAsset_Library_Scheme = "assets-library"
 class AudioMain{
     static func compress_audio(_ fileUrl: String, optionMap: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
+            let fileUrl = fileUrl.replacingOccurrences(of: "file://", with: "")
             let fileManager = FileManager.default
             var isDir: ObjCBool = false
             if !fileManager.fileExists(atPath: fileUrl, isDirectory: &isDir) || isDir.boolValue {

--- a/ios/Audio/AudioMain.swift
+++ b/ios/Audio/AudioMain.swift
@@ -14,12 +14,6 @@ let AlAsset_Library_Scheme = "assets-library"
 class AudioMain{
     static func compress_audio(_ fileUrl: String, optionMap: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            var fileUrl = fileUrl
-            
-            if fileUrl.hasPrefix("file://") {
-                fileUrl = fileUrl.replacingOccurrences(of: "file://", with: "")
-            }
-          
             let fileManager = FileManager.default
             var isDir: ObjCBool = false
             if !fileManager.fileExists(atPath: fileUrl, isDirectory: &isDir) || isDir.boolValue {
@@ -27,19 +21,19 @@ class AudioMain{
                 reject(String(err.code), err.localizedDescription, err)
                 return
             }
-            
+
             let audioOptions = AudioOptions.fromDictionary((optionMap as! [String : Any]))
-            let outputMp3Path = "file://\(Utils.generateCacheFilePath("m4a"))"
-            
-            let oldUfileUrlRL = URL(string: fileUrl)!
-            let newURL = URL(string: outputMp3Path)!
-            
+            let outputMp3Path = Utils.generateCacheFilePath("m4a")
+
+            let oldUfileUrlRL = URL(fileURLWithPath: fileUrl)
+            let newURL = URL(fileURLWithPath: outputMp3Path)
+
             var options = FormatConverter.Options()
-            
+
             if(audioOptions.samplerate != -1){
                 options.sampleRate = Double(audioOptions.samplerate)
             }
-            
+
             if(audioOptions.bitrate != -1){
                 options.bitRate = UInt32(audioOptions.bitrate)
             }
@@ -49,16 +43,16 @@ class AudioMain{
                 print("output bitrate: \(bitrate)")
                 options.bitRate = UInt32(bitrate)
             }
-            
-            
+
+
             if(audioOptions.channels != -1){
                 options.channels = UInt32(audioOptions.channels)
             }
-         
+
             options.format = .m4a
             options.eraseFile = false
             options.bitDepthRule = .any
-             
+
             let converter = FormatConverter(inputURL: oldUfileUrlRL, outputURL: newURL, options: options)
             converter.start { error in
             // check to see if error isn't nil, otherwise you're good
@@ -68,10 +62,10 @@ class AudioMain{
                     reject(error?.localizedDescription,error?.localizedDescription, error)
                     return
                 }
-               
+
                 resolve(newURL.absoluteString)
             }
-            
+
         } catch {
             reject(error.localizedDescription, error.localizedDescription, nil)
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I found that in the latest version of iOS 17.x, calling Audio.compress to compress wav files always resulted in an error. After investigation, I found that URLWithString changed [its behavior](https://developer.apple.com/documentation/foundation/nsurl/1572047-urlwithstring). I fixed this bug by adjusting it to another [unambiguous API](https://developer.apple.com/documentation/foundation/nsurl/1410828-fileurlwithpath).

## Changelog



[fix] [Audio] - call `Audio.compress` always failed under iOS 17

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
