### PR TITLE
fix(mp4parser): now works from 1.0.6 to 1.1.22

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,6 +111,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I applied both changes from the main repo to the Track file that seems to be essentially copy pasta from there
mp4parser was bumped in our repo because of https://github.com/intercom/intercom-react-native .

## Changelog

[FIX] [ANDROID] - No sound when mp4parser was in a version greater than 1.0.6

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
