### PR TITLE
fix: ios manual image compress fixed

### DIFF
--- a/ios/Image/ImageCompressor.swift
+++ b/ios/Image/ImageCompressor.swift
@@ -176,7 +176,7 @@ class ImageCompressor {
            
         }
         
-        data=copyExifInfo(actualImagePath: actualImagePath, image: image, data: data)
+        data=copyExifInfo(actualImagePath: actualImagePath, image: UIImage(data: data) ?? image, data: data)
         
         
         if isBase64 {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Different 'quality' param does not affect image compression for iOS. Working fine on Android. Its related to used source image of copyExifinfo func so i chaned it. Related issue https://github.com/numandev1/react-native-compressor/issues/287

## Changelog



[FIX] [IOS] - Manuel image compress changed source image with compressed image source

## Test Plan

Select flowers picture in ios simulator [image](https://github.com/numandev1/react-native-compressor/assets/54990817/f25d07d2-ab5a-4ebd-8d92-cf0dfd119205)

const thumbnailPath1 = await Image.compress(url, {
  compressionMethod: 'manual',
  maxWidth: 1280,
  maxHeight: 1280,
  quality: 1,
});

const thumbnailPath2 = await Image.compress(url, {
  compressionMethod: 'manual',
  maxWidth: 1280,
  maxHeight: 1280,
  quality: 0.75,
});

const thumbnailPath3 = await Image.compress(url, {
  compressionMethod: 'manual',
  maxWidth: 1280,
  maxHeight: 1280,
  quality: 0.5,
});

const thumbnailPath4 = await Image.compress(url, {
  compressionMethod: 'manual',
  maxWidth: 1280,
  maxHeight: 1280,
  quality: 0.25,
});

const thumbnailPath5 = await Image.compress(url, {
  compressionMethod: 'manual',
  maxWidth: 1280,
  maxHeight: 1280,
  quality: 0.1,
});

console.log('1', await getFileSize(thumbnailPath1));
console.log('2', await getFileSize(thumbnailPath2));
console.log('3', await getFileSize(thumbnailPath3));
console.log('4', await getFileSize(thumbnailPath4));
console.log('5', await getFileSize(thumbnailPath5));

Log Before PR Result:

1 605016
2 605016
3 605016
4 605016
5 605016

Log After PR: 

1 829608
2 594301
3 488911
4 344909
5 609105
