### PR TITLE
Fix issue 256 :Build error at ImageCompressor.swift file - Cannot find 'RCTResizeMode' in scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-compressor",
-  "version": "1.8.24",
+  "version": "1.8.25",
   "description": "Compress Image, Video, and Audio same like Whatsapp & Auto/Manual Compression | Background Upload | Download File | Create Video Thumbnail",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
Build error at ImageCompressor.swift file - Cannot find 'RCTResizeMode' in scope
https://github.com/numandev1/react-native-compressor/issues/256

## Changelog
Added below line in `ios/Compressor-Bridging-Header.h`
`+#import <React/RCTResizeMode.h>`

