### PR TITLE
Remove duplicate codegen spec for video compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,11 +197,6 @@
         "name": "RNCompressorSpec",
         "type": "modules",
         "jsSrcsDir": "src"
-      },
-      {
-        "name": "RNVideoCompressorSpec",
-        "type": "modules",
-        "jsSrcsDir": "src"
       }
     ]
   }


### PR DESCRIPTION
## Summary

This PR addresses an issue where iOS builds were failing due to duplicate symbols. The root cause was traced to the presence of two separate codegen specs in the package.json file: RNCompressorSpec and RNVideoCompressorSpec.

It appears that the RNCompressorSpec is sufficient to generate the necessary native code for both image and video compression. The separate RNVideoCompressorSpec was causing duplication in the generated code, leading to build failures.

This change simplifies the package configuration without compromising functionality. It's recommended to thoroughly test this change across different React Native versions and build configurations to ensure there are no unintended side effects.

## Changelog
- Removed the RNVideoCompressorSpec entry from the codegenConfig in package.json

## Test Plan

- Tested iOS builds before and after the change using React Native 74.0
- Verified that image and video compression still work as expected