### PR TITLE
feat: move to isoparser 1.9.X

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,7 +115,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
-  implementation "com.googlecode.mp4parser:isoparser:1.0.6"
+  implementation 'org.mp4parser:isoparser:1.9.56'
   implementation 'com.github.banketree:AndroidLame-kotlin:v0.0.1'
   implementation 'javazoom:jlayer:1.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,7 +111,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"

--- a/android/src/main/java/com/reactnativecompressor/Utils/Utils.kt
+++ b/android/src/main/java/com/reactnativecompressor/Utils/Utils.kt
@@ -14,9 +14,10 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.ByteBuffer
 import java.util.UUID
 import java.util.regex.Pattern
-import kotlin.Throwable
+
 
 object Utils {
     private const val TAG = "react-native-compessor"
@@ -327,5 +328,13 @@ object Utils {
     } else {
       -1L
     }
+  }
+
+  fun subBuffer(buf: ByteBuffer, start: Int, count: Int = buf.remaining() - start): ByteBuffer {
+    val newBuf = buf.duplicate()
+    val bytes = ByteArray(count)
+    newBuf.position(start)
+    newBuf[bytes, 0, bytes.size]
+    return ByteBuffer.wrap(bytes)
   }
 }

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/MP4Builder.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/MP4Builder.kt
@@ -2,8 +2,10 @@ package com.reactnativecompressor.Video.VideoCompressor.video
 
 import android.media.MediaCodec
 import android.media.MediaFormat
-import com.coremedia.iso.boxes.*
-import com.googlecode.mp4parser.util.Matrix
+import org.mp4parser.Box
+import org.mp4parser.boxes.iso14496.part12.*
+
+import org.mp4parser.support.Matrix
 import java.io.FileOutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
@@ -42,7 +44,7 @@ class MP4Builder {
     @Throws(Exception::class)
     private fun flushCurrentMdat() {
         val oldPosition = fc.position()
-        fc.position(mdat.offset)
+        fc.position(mdat.getOffset())
         mdat.getBox(fc)
         fc.position(oldPosition)
         mdat.setDataOffset(0)

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Mdat.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Mdat.kt
@@ -1,11 +1,11 @@
 package com.reactnativecompressor.Video.VideoCompressor.video
 
-import com.coremedia.iso.BoxParser
-import com.coremedia.iso.IsoFile
-import com.coremedia.iso.IsoTypeWriter
-import com.coremedia.iso.boxes.Box
-import com.coremedia.iso.boxes.Container
-import com.googlecode.mp4parser.DataSource
+import org.mp4parser.Box
+import org.mp4parser.BoxParser
+import org.mp4parser.Container
+import org.mp4parser.IsoFile
+import org.mp4parser.tools.IsoTypeWriter
+
 import java.nio.ByteBuffer
 import java.nio.channels.WritableByteChannel
 
@@ -15,15 +15,15 @@ class Mdat : Box {
     private var contentSize = (1024 * 1024 * 1024).toLong()
     private var dataOffset: Long = 0
 
-    override fun getParent(): Container = parent
+  fun getParent(): Container = parent
 
-    override fun setParent(parent: Container) {
+  fun setParent(parent: Container) {
         this.parent = parent
     }
 
     override fun getSize(): Long = 16 + contentSize
 
-    override fun getOffset(): Long = dataOffset
+  fun getOffset(): Long = dataOffset
 
     fun setDataOffset(offset: Long) {
         dataOffset = offset
@@ -62,13 +62,5 @@ class Mdat : Box {
         }
         bb.rewind()
         writableByteChannel.write(bb)
-    }
-
-    override fun parse(
-        dataSource: DataSource?,
-        header: ByteBuffer?,
-        contentSize: Long,
-        boxParser: BoxParser?
-    ) {
     }
 }

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Mp4Movie.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Mp4Movie.kt
@@ -2,7 +2,7 @@ package com.reactnativecompressor.Video.VideoCompressor.video
 
 import android.media.MediaCodec
 import android.media.MediaFormat
-import com.googlecode.mp4parser.util.Matrix
+import org.mp4parser.support.Matrix
 import java.io.File
 import java.util.*
 

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Track.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Track.kt
@@ -13,9 +13,7 @@ import org.mp4parser.boxes.iso14496.part14.ESDescriptorBox
 import org.mp4parser.boxes.iso14496.part15.AvcConfigurationBox
 import org.mp4parser.boxes.sampleentry.AudioSampleEntry
 import org.mp4parser.boxes.sampleentry.VisualSampleEntry
-import java.nio.ByteBuffer
 import java.util.*
-import kotlin.reflect.jvm.isAccessible
 
 class Track(id: Int, format: MediaFormat, audio: Boolean) {
 
@@ -172,39 +170,15 @@ class Track(id: Int, format: MediaFormat, audio: Boolean) {
 
             val audioSpecificConfig = AudioSpecificConfig()
 
-            // Fix for com.googlecode.mp4parser:isoparser multiple version management
-            // Updates based on
-            // https://github.com/sannies/mp4parser/commit/9cf7f9185b294ac4fa1cd86be1915cd355d859eb#diff-5860894eeaba912c09de175e617d53d5beecebeadd2b64695ed736f9e598bf55
-            // and
-            // https://github.com/sannies/mp4parser/commit/b85f62274b56cc68d6c6e3dc2f9d4e23318e3341#diff-5860894eeaba912c09de175e617d53d5beecebeadd2b64695ed736f9e598bf55
-            //
-            val method = audioSpecificConfig::class.members.firstOrNull { it.name == "setOriginalAudioObjectType" }
-            if (method != null) {
-                // com.googlecode.mp4parser:isoparser is >= 1.1
-                method.isAccessible = true
-                method.call(audioSpecificConfig, 2)
-                audioSpecificConfig.setSamplingFrequencyIndex(
-                    samplingFrequencyIndexMap[audioSampleEntry.sampleRate.toInt()]!!
-                )
-                audioSpecificConfig.setChannelConfiguration(audioSampleEntry.channelCount)
-                decoderConfigDescriptor.audioSpecificInfo = audioSpecificConfig
-                descriptor.decoderConfigDescriptor = decoderConfigDescriptor
+            audioSpecificConfig.setOriginalAudioObjectType(2)
+            audioSpecificConfig.setSamplingFrequencyIndex(
+                samplingFrequencyIndexMap[audioSampleEntry.sampleRate.toInt()]!!
+            )
+            audioSpecificConfig.setChannelConfiguration(audioSampleEntry.channelCount)
+            decoderConfigDescriptor.audioSpecificInfo = audioSpecificConfig
+            descriptor.decoderConfigDescriptor = decoderConfigDescriptor
 
-                esds.esDescriptor = descriptor
-            } else {
-                // com.googlecode.mp4parser:isoparser is < 1.1 (eg: 1.0.6)
-                audioSpecificConfig.setAudioObjectType(2)
-                audioSpecificConfig.setSamplingFrequencyIndex(
-                    samplingFrequencyIndexMap[audioSampleEntry.sampleRate.toInt()]!!
-                )
-                audioSpecificConfig.setChannelConfiguration(audioSampleEntry.channelCount)
-                decoderConfigDescriptor.audioSpecificInfo = audioSpecificConfig
-                descriptor.decoderConfigDescriptor = decoderConfigDescriptor
-
-                val data = descriptor.serialize()
-                esds.esDescriptor = descriptor
-                esds.data = data
-            }
+            esds.esDescriptor = descriptor
 
             audioSampleEntry.addBox(esds)
             sampleDescriptionBox.addBox(audioSampleEntry)

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Track.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Track.kt
@@ -3,15 +3,17 @@ package com.reactnativecompressor.Video.VideoCompressor.video
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
-import com.coremedia.iso.boxes.SampleDescriptionBox
-import com.coremedia.iso.boxes.sampleentry.AudioSampleEntry
-import com.coremedia.iso.boxes.sampleentry.VisualSampleEntry
-import com.googlecode.mp4parser.boxes.mp4.ESDescriptorBox
-import com.googlecode.mp4parser.boxes.mp4.objectdescriptors.AudioSpecificConfig
-import com.googlecode.mp4parser.boxes.mp4.objectdescriptors.DecoderConfigDescriptor
-import com.googlecode.mp4parser.boxes.mp4.objectdescriptors.ESDescriptor
-import com.googlecode.mp4parser.boxes.mp4.objectdescriptors.SLConfigDescriptor
-import com.mp4parser.iso14496.part15.AvcConfigurationBox
+import com.reactnativecompressor.Utils.Utils
+import org.mp4parser.boxes.iso14496.part1.objectdescriptors.AudioSpecificConfig
+import org.mp4parser.boxes.iso14496.part1.objectdescriptors.DecoderConfigDescriptor
+import org.mp4parser.boxes.iso14496.part1.objectdescriptors.ESDescriptor
+import org.mp4parser.boxes.iso14496.part1.objectdescriptors.SLConfigDescriptor
+import org.mp4parser.boxes.iso14496.part12.SampleDescriptionBox
+import org.mp4parser.boxes.iso14496.part14.ESDescriptorBox
+import org.mp4parser.boxes.iso14496.part15.AvcConfigurationBox
+import org.mp4parser.boxes.sampleentry.AudioSampleEntry
+import org.mp4parser.boxes.sampleentry.VisualSampleEntry
+import java.nio.ByteBuffer
 import java.util.*
 import kotlin.reflect.jvm.isAccessible
 
@@ -67,28 +69,10 @@ class Track(id: Int, format: MediaFormat, audio: Boolean) {
                     VisualSampleEntry(VisualSampleEntry.TYPE3).setup(width, height)
 
                 val avcConfigurationBox = AvcConfigurationBox()
-                if (format.getByteBuffer("csd-0") != null) {
-                    val spsArray = ArrayList<ByteArray>()
-                    val spsBuff = format.getByteBuffer("csd-0")
-                    spsBuff!!.position(4)
-
-                    val spsBytes = ByteArray(spsBuff.remaining())
-                    spsBuff[spsBytes]
-                    spsArray.add(spsBytes)
-
-                    val ppsArray = ArrayList<ByteArray>()
-                    val ppsBuff = format.getByteBuffer("csd-1")
-                    ppsBuff?.let {
-                        it.position(4)
-
-                        val ppsBytes = ByteArray(it.remaining())
-                        it[ppsBytes]
-
-                        ppsArray.add(ppsBytes)
-                        avcConfigurationBox.sequenceParameterSets = spsArray
-                        avcConfigurationBox.pictureParameterSets = ppsArray
-                    }
-                }
+                avcConfigurationBox.sequenceParameterSets =
+                  format.getByteBuffer("csd-0")?.let { listOf(Utils.subBuffer(it, 4)) }
+                avcConfigurationBox.pictureParameterSets =
+                  format.getByteBuffer("csd-1")?.let { listOf(Utils.subBuffer(it, 4)) }
 
                 if (format.containsKey("level")) {
                     when (format.getInteger("level")) {


### PR DESCRIPTION
Hello, here is a draft supporting the newest version of isoparser.

## Summary

One of our dependency (intercom) again bumped their version of isoparser and both could not be used at the same time.
This PR updates to latest to allow use using both libraries at the same time.

However, this change is not backward compatible nor I know how I would achieve something that'd work on both versions as I did with 1.0 & 1.1

Feel free to use / merge / modify this if you want.

We'll probably use patch-package on our side but I wanted to share this work.

## Changelog

[REFACTOR][DEPENDENCY]: update isoparser to version 1.9+

## Test Plan

Used the example app to make sure everything was OK.