### PR TITLE
fix(ios): fix crash when processing file size of an unparsed URL

### DIFF
--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -110,20 +110,24 @@ class Utils {
     static func getfileSizeInBytes(forURL url: Any) -> Double {
         var fileURL: URL?
         var fileSize: Double = 0.0
-        if (url is URL) || (url is String)
-        {
-            if (url is URL) {
-                fileURL = url as? URL
-            }
-            else {
-                fileURL = URL(fileURLWithPath: url as! String)
-            }
-            var fileSizeValue = 0.0
-            try? fileSizeValue = (fileURL?.resourceValues(forKeys: [URLResourceKey.fileSizeKey]).allValues.first?.value as! Double?)!
-            if fileSizeValue > 0.0 {
-                fileSize = Double(fileSizeValue)
-            }
+        
+        if (url is URL) {
+            let urlWithSlash = Utils.slashifyFilePath(path: (url as? URL)?.absoluteString)
+            fileURL = URL(string: urlWithSlash!)
+        } else if (url is String) {
+            let urlWithSlash = Utils.slashifyFilePath(path: url as? String)
+            fileURL = URL(fileURLWithPath: urlWithSlash!)
+        } else {
+            return fileSize
         }
+        
+        var fileSizeValue = 0.0
+        
+        try? fileSizeValue = (fileURL?.resourceValues(forKeys: [URLResourceKey.fileSizeKey]).allValues.first?.value as! Double?)!
+        if fileSizeValue > 0.0 {
+            fileSize = Double(fileSizeValue)
+        }
+        
         return fileSize
     }
     


### PR DESCRIPTION
## Summary

Me and [other users](https://github.com/numandev1/react-native-compressor/issues/221#issuecomment-2040812532) were figuring a crash on iOS. After some investigation it was happening in the `getfileSizeInBytes` utils method, where it sometimes received paths like `/path/to/file` instead of `file:///path/to/file`.
This fix make sure that we "slashify" received path.

## Changelog

[IOS] [FIX] - Fix possible crash when processing file sizes

## Test Plan

I only tested this patch on my company app, and everything went well. I also debugged the code on Xcode in order to make sure every variables are correctly set.
