### PR TITLE
Fix iOS playback error for certain Android-compressed videos

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Track.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/videoHelpers/Track.kt
@@ -258,10 +258,7 @@ class Track(id: Int, format: MediaFormat, audio: Boolean) {
     }
 
     private fun AudioSampleEntry.setup(format: MediaFormat): AudioSampleEntry = apply {
-        channelCount =
-            if (format.getInteger(MediaFormat.KEY_CHANNEL_COUNT) == 1) 2 else format.getInteger(
-                MediaFormat.KEY_CHANNEL_COUNT
-            )
+        channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
         sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE).toLong()
         dataReferenceIndex = 1
         sampleSize = 16


### PR DESCRIPTION
## Description

This PR fixes an iOS playback error that occurs when playing certain videos compressed by the Android app. The AAC decoder on iOS fails with errors such as `maxSFB long exceeds maximum allowed value` due to incorrect audio channel settings.

## Root Cause

The issue was caused by the `AudioSampleEntry.setup()` method, which forced mono audio (1 channel) to be treated as stereo (2 channels). This resulted in incorrect audio format information that iOS couldn't decode properly.

## Solution

Fixed by preserving the original audio channel count during compression.

## Testing

Verified that the fix resolves playback errors on iOS for affected videos.

## Related Issue

Fixes #268.