### PR TITLE
Move uuidv4 to helper to avoid circular dependency with React Compiler

### DIFF
--- a/src/utils/Downloader.tsx
+++ b/src/utils/Downloader.tsx
@@ -2,7 +2,7 @@ import { NativeEventEmitter, Platform } from 'react-native';
 import type { NativeEventSubscription } from 'react-native';
 import { Compressor } from '../Main';
 const CompressEventEmitter = new NativeEventEmitter(Compressor);
-import { uuidv4 } from './index';
+import { uuidv4 } from './helpers';
 export const download = async (
   fileUrl: string,
   downloadProgress?: (progress: number) => void,

--- a/src/utils/Uploader.tsx
+++ b/src/utils/Uploader.tsx
@@ -2,7 +2,7 @@ import { NativeEventEmitter, Platform } from 'react-native';
 import type { NativeEventSubscription } from 'react-native';
 import { Compressor } from '../Main';
 const CompressEventEmitter = new NativeEventEmitter(Compressor);
-import { uuidv4 } from './index';
+import { uuidv4 } from './helpers';
 export enum UploadType {
   BINARY_CONTENT = 0,
   MULTIPART = 1,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,15 @@
+export const uuidv4 = () => {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r =
+        (parseFloat(
+          '0.' +
+            Math.random().toString().replace('0.', '') +
+            new Date().getTime()
+        ) *
+          16) |
+        0,
+      // eslint-disable-next-line eqeqeq
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -194,20 +194,6 @@ export const getFileSize = async (filePath: string): Promise<string> => {
   return Compressor.getFileSize(filePath);
 };
 
-export const uuidv4 = () => {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r =
-        (parseFloat(
-          '0.' +
-            Math.random().toString().replace('0.', '') +
-            new Date().getTime()
-        ) *
-          16) |
-        0,
-      // eslint-disable-next-line eqeqeq
-      v = c == 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-};
 export * from './Downloader';
 export * from './Uploader';
+export * from './helpers';


### PR DESCRIPTION
## Summary

When React Compiler is enabled, there is a circular dependency issue causing `uuidv4` to be `undefined` during background uploads. This PR resolves it by moving the `uuidv4` utility out of `index.ts` and into a separate `helpers.ts` file, avoiding the import loop.

## Changelog

[Fix] [Bug] - Avoid circular dependency by isolating `uuidv4` export in helper module
