### PR TITLE
Fix kotlin build error - change deprecated `toLowerCase()` to `lowercase()`

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Audio/AudioHelper.kt
+++ b/android/src/main/java/com/reactnativecompressor/Audio/AudioHelper.kt
@@ -58,7 +58,7 @@ class AudioHelper {
       var destinationBitrate = originalBitrate
       Utils.addLog("source bitrate: $originalBitrate")
 
-      when (quality.toLowerCase()) {
+      when (quality.lowercase()) {
         "low" -> destinationBitrate = maxOf(64, (originalBitrate * 0.3).toInt())
         "medium" -> destinationBitrate = (originalBitrate * 0.5).toInt()
         "high" -> destinationBitrate = minOf(320, (originalBitrate * 0.7).toInt())

--- a/android/src/main/java/com/reactnativecompressor/Utils/Uploader.kt
+++ b/android/src/main/java/com/reactnativecompressor/Utils/Uploader.kt
@@ -161,7 +161,7 @@ class Uploader(private val reactContext: ReactApplicationContext) {
     if (mimeType == null) {
       val fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileUri.toString())
       if (fileExtension != null) {
-        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension.toLowerCase())
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension.lowercase())
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes https://github.com/numandev1/react-native-compressor/issues/350

React Native 0.80 ships with Kotlin version 2.1.20 ([source](https://reactnative.dev/blog/2025/06/12/react-native-0.80#android))

`toLowerCase()` is no longer available - it has long been deprecated, and now as of version 2.1 causes build errors. We just need to switch it to `lowercase()`

## Changelog

[Android] [Fix] - Fix build error in React Native 0.80

## Test Plan

Upgrade example app to 0.80, confirm it builds. Note: I haven't added this to this PR, I can if you'd like.
